### PR TITLE
Patch catastrophic memory usage on long tuples

### DIFF
--- a/ragg/cfg-parser/cfg-parser.rkt
+++ b/ragg/cfg-parser/cfg-parser.rkt
@@ -675,6 +675,11 @@
                                                                   (if (null? pats)
                                                                       #'(fail-k max-depth tasks)
                                                                       #`(parse-parallel-or
+
+                                                                         #;#,(if (or (null? (cdr pats))
+                                                                                     (car simple?s))
+                                                                                 #'parse-or
+                                                                                 #'parse-parallel-or)
                                                                          (lambda (stream last-consumed-token depth end success-k fail-k max-depth tasks)
                                                                            #,(build-match nts
                                                                                           toks 

--- a/ragg/test/exercise-python-grammar.rkt
+++ b/ragg/test/exercise-python-grammar.rkt
@@ -89,3 +89,35 @@ EOF
                  (adapt-python-tokenizer (open-input-string "sqrt(x^2+y^2)")
                                          #:end-marker-to-eof? #t)))
  '(expr (xor_expr (and_expr (shift_expr (arith_expr (term (factor (power (atom "sqrt") (trailer "(" (arglist (argument (test (or_test (and_test (not_test (comparison (expr (xor_expr (and_expr (shift_expr (arith_expr (term (factor (power (atom "x"))))))) "^" (and_expr (shift_expr (arith_expr (term (factor (power (atom "2")))) "+" (term (factor (power (atom "y"))))))) "^" (and_expr (shift_expr (arith_expr (term (factor (power (atom "2")))))))))))))))) ")"))))))))))
+
+(define (make-tuple-stream n)
+  (open-input-string 
+   (string-append "(" (string-append* (make-list n "1,")) ")")))
+
+
+;; Check for catastrophic memory usage through performance
+(check-true
+ (let ((parser-thread 
+        (thread (lambda ()
+                  (parse-expr (adapt-python-tokenizer (make-tuple-stream 50)
+                                                      #:end-marker-to-eof? #t))))))
+   (sleep 1)
+   (if 
+    (thread-running? parser-thread)
+    (begin (kill-thread parser-thread)
+           #f)
+    #t))
+ "50 item tuple times out after 1s")
+
+(check-true
+ (let ((parser-thread 
+        (thread (lambda ()
+                  (parse-expr (adapt-python-tokenizer (make-tuple-stream 500)
+                                                      #:end-marker-to-eof? #t))))))
+   (sleep 10)
+   (if 
+    (thread-running? parser-thread)
+    (begin (kill-thread parser-thread)
+           #f)
+    #t))
+ "500 item tuple times out after 10s")


### PR DESCRIPTION
I don't know the root problem (or whether it is in the ragg codebase at all), but using only parallel-or (no parse-or) in the lhs functions patches it. The surface problem is the cfg-parser runtime accumulating noticeable memory on long tuples (and other testlist rules) and all available memory somewhere over 500 items (about 2GB on my system).

I included some fungible hardcoded timing tests to demonstrate this. The 500 item test I added does pass/fail as expected on my machine.
