### PR TITLE
Add package dependencies and collection flag

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,7 @@
+#lang setup/infotab
+
+(define deps '("base" "parser-tools-lib" "rackunit-lib"))
+(define build-deps '("at-exp-lib" "parser-tools-doc" "racket-doc"
+                     "scribble-lib"))
+(define collection 'multi)
+


### PR DESCRIPTION
This PR adds the `collection` flag that was added for Racket v5.92/6.0 and updates the package's dependency metadata.
